### PR TITLE
Add datetime and date encoding

### DIFF
--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -227,6 +227,11 @@ defmodule Mariaex.Messages do
     do: {0, :field_type_longlong, << int :: 64-little >>}
   def encode_param(float) when is_float(float),
     do: {0, :field_type_newdecimal, << float :: 64-little-float >>}
+  def encode_param({{year, month, day}}),
+    do: {0, :field_type_date, << 4::8-little, year::16-little, month::8-little, day::8-little>>}
+  def encode_param({{year, month, day}, {hour, min, sec}}),
+    do: {0, :field_type_datetime, << 7::8-little, year::16-little, month::8-little, day::8-little,
+      hour::8-little, min::8-little, sec::8-little>>}
 
   def encode_msg(rec = stmt_execute(parameters: parameters, )) do
     bin = parameters_to_binary(parameters)

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1,4 +1,4 @@
-defmodule MariaexTest do
+defmodule QueryTest do
   use ExUnit.Case, async: true
   import Mariaex.TestHelper
 
@@ -40,6 +40,15 @@ defmodule MariaexTest do
     assert [{{{2013,12,21},{23,1,27}}}] = query("SELECT timestamp('2013-12-21 23:01:27 EST')", [])
   end
 
+  test "encode and decode dates", context do
+    date = {2010, 10, 17}
+    time = {19, 27, 30}
+
+    assert :ok = query("CREATE TABLE test_date_encoding (id int, date date, timestamp timestamp)", [])
+    assert :ok = query("INSERT INTO test_date_encoding (date, timestamp) VALUES(?, ?)", [{date}, {date, time}])
+
+    assert [{date, {date, time}}] = query("SELECT date, timestamp FROM test_date_encoding", [])
+  end
 
   test "non data statement", context do
     assert :ok = query("BEGIN", [])
@@ -76,5 +85,4 @@ defmodule MariaexTest do
     assert :ok = query("INSERT INTO test_statements VALUES(?, ?)", [2, "test2"])
     assert [{1, "test1"}, {2, "test2"}] = query("SELECT id, text FROM test_statements WHERE id > ?", [0])
   end
-
 end


### PR DESCRIPTION
It adds the date/datetime encoding. Huge thanks to @josevalim that guided my towards the solution :heart: 

~~Also I created a new file so separate the encoding/decoding tests. What do you think?~~ Changed the `mariaex_test.exs` to `query_test.exs`

:. The documentation for the binary protocol -> http://dev.mysql.com/doc/internals/en/binary-protocol-value.html cc/ @bernardoamc