### PR TITLE
Decode in binary protocol

### DIFF
--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -268,8 +268,8 @@ defmodule Mariaex.Messages do
   defp decode_msg(body, :rows),                                                    do: __decode__(:row, body)
 
   defp decode_string(data),    do: data
-  defp decode_float(data),     do: Float.parse(data) |> elem(0)
-  defp decode_integer(data),   do: Integer.parse(data) |> elem(0)
+  defp decode_float(data),     do: String.to_float(data)
+  defp decode_integer(data),   do: String.to_integer(data)
   defp decode_bit(<<bit>>),    do: bit
   defp decode_null(_),         do: nil
   defp decode_boolean("1"),    do: true

--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -320,14 +320,23 @@ defmodule Mariaex.Messages do
   end
 
   defp handle_decode_bin_rows({:string, _mysql_type}, packet),              do: length_encoded_string(packet)
-  defp handle_decode_bin_rows({:integer, :field_type_tiny}, packet),        do: parse_packet(packet, 8)
-  defp handle_decode_bin_rows({:integer, :field_type_long}, packet),        do: parse_packet(packet, 32)
-  defp handle_decode_bin_rows({:integer, :field_type_longlong}, packet),    do: parse_packet(packet, 64)
+  defp handle_decode_bin_rows({:integer, :field_type_tiny}, packet),        do: parse_int_packet(packet, 8)
+  defp handle_decode_bin_rows({:integer, :field_type_long}, packet),        do: parse_int_packet(packet, 32)
+  defp handle_decode_bin_rows({:integer, :field_type_longlong}, packet),    do: parse_int_packet(packet, 64)
   defp handle_decode_bin_rows({:time, :field_type_time}, packet),           do: parse_time_packet(packet)
   defp handle_decode_bin_rows({:date, :field_type_date}, packet),           do: parse_date_packet(packet)
   defp handle_decode_bin_rows({:timestamp, :field_type_datetime}, packet),  do: parse_datetime_packet(packet)
+  defp handle_decode_bin_rows({:boolean, :field_type_tiny}, packet),        do: parse_boolean(packet)
 
-  defp parse_packet(packet, size) do
+  defp parse_boolean(packet) do
+    << value, rest :: binary >> = packet
+    case value do
+      1 -> {true, rest}
+      0 -> {false, rest}
+    end
+  end
+
+  defp parse_int_packet(packet, size) do
     << value :: size(size)-little, rest :: binary >> = packet
     {value, rest}
   end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -8,7 +8,41 @@ defmodule QueryTest do
     {:ok, [pid: pid]}
   end
 
-  test "support primitive data types", context do
+  test "support primitive data types by binary protocol", context do
+    integer = 1
+    float   = 3.1415
+    string  = "Californication"
+    text    = "Some random text"
+    binary  = <<0,1>>
+    decimal = Decimal.new("16.90")
+    table   = "basic_types_binary_protocol"
+
+    sql = ~s{CREATE TABLE #{table} } <>
+          ~s{(id serial, active boolean, count integer, intensity float, } <>
+          ~s{title varchar(20), body text(20), data blob, value decimal(10,2))}
+
+    :ok = query(sql, [])
+    insert = ~s{INSERT INTO #{table} (active, count, intensity, title, body, data, value) } <>
+             ~s{VALUES (?, ?, ?, ?, ?, ?, ?)}
+    :ok = query(insert, [true, integer, float, string, text, binary, decimal])
+
+    # Boolean
+    [{true}] = query("SELECT active from #{table} WHERE id = ?", [1])
+
+    # Integer
+    [{^integer}] = query("SELECT count from #{table} WHERE id = ?", [1])
+
+    # String
+    [{^string}] = query("SELECT title from #{table} WHERE id = ?", [1])
+
+    # Text
+    [{^text}] = query("SELECT body from #{table} WHERE id = ?", [1])
+
+    # Binary
+    [{^binary}] = query("SELECT data from #{table} WHERE id = ?", [1])
+  end
+
+  test "support primitive data types by text protocol", context do
     integer          = 1
     negative_integer = -1
     float            = 3.1415
@@ -16,7 +50,7 @@ defmodule QueryTest do
     string           = "Californication"
     text             = "Some random text"
     binary           = <<0,1>>
-    table            = "basic_types"
+    table            = "basic_types_text_protocol"
 
     sql = ~s{CREATE TABLE #{table} } <>
           ~s{(id serial, active boolean, count integer, intensity float, } <>
@@ -24,7 +58,7 @@ defmodule QueryTest do
 
     :ok = query(sql, [])
 
-    # Booleans
+    # Boolean
     :ok = query("INSERT INTO #{table} (active) values (?)", [true])
     [{true}] = query("SELECT active from #{table} WHERE id = LAST_INSERT_ID()", [])
 


### PR DESCRIPTION
It adds support for decoding binaries and adds test cases.

Today we have two protocols, text and binary.

```
query(sql, []) # Uses a text protocol at the moment. 
query(sql, params) # Uses a binary protocol
```

This PR does not add support for all types, there are some others that we have to work: `float`, `decimal`.