### PR TITLE
Decode in binary protocol

### DIFF
--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -326,9 +326,10 @@ defmodule Mariaex.Messages do
   defp handle_decode_bin_rows({:time, :field_type_time}, packet),           do: parse_time_packet(packet)
   defp handle_decode_bin_rows({:date, :field_type_date}, packet),           do: parse_date_packet(packet)
   defp handle_decode_bin_rows({:timestamp, :field_type_datetime}, packet),  do: parse_datetime_packet(packet)
-  defp handle_decode_bin_rows({:boolean, :field_type_tiny}, packet),        do: parse_boolean(packet)
+  defp handle_decode_bin_rows({:boolean, :field_type_tiny}, packet),        do: parse_boolean_packet(packet)
+  defp handle_decode_bin_rows({:decimal, :field_type_newdecimal}, packet),  do: parse_decimal_packet(packet)
 
-  defp parse_boolean(packet) do
+  defp parse_boolean_packet(packet) do
     << value, rest :: binary >> = packet
     case value do
       1 -> {true, rest}
@@ -338,6 +339,12 @@ defmodule Mariaex.Messages do
 
   defp parse_int_packet(packet, size) do
     << value :: size(size)-little, rest :: binary >> = packet
+    {value, rest}
+  end
+
+  defp parse_decimal_packet(packet) do
+    << length,  raw_value :: size(length)-little-binary, rest :: binary >> = packet
+    value = Decimal.new(raw_value)
     {value, rest}
   end
 

--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -328,6 +328,7 @@ defmodule Mariaex.Messages do
   defp handle_decode_bin_rows({:timestamp, :field_type_datetime}, packet),  do: parse_datetime_packet(packet)
   defp handle_decode_bin_rows({:boolean, :field_type_tiny}, packet),        do: parse_boolean_packet(packet)
   defp handle_decode_bin_rows({:decimal, :field_type_newdecimal}, packet),  do: parse_decimal_packet(packet)
+  defp handle_decode_bin_rows({:float, :field_type_double}, packet),        do: parse_float_packet(packet, 64)
 
   defp parse_boolean_packet(packet) do
     << value, rest :: binary >> = packet
@@ -337,6 +338,10 @@ defmodule Mariaex.Messages do
     end
   end
 
+  defp parse_float_packet(packet, size) do
+    << value :: size(size)-float-little, rest :: binary >> = packet
+    {value, rest}
+  end
   defp parse_int_packet(packet, size) do
     << value :: size(size)-little, rest :: binary >> = packet
     {value, rest}

--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -328,6 +328,7 @@ defmodule Mariaex.Messages do
   defp handle_decode_bin_rows({:timestamp, :field_type_datetime}, packet),  do: parse_datetime_packet(packet)
   defp handle_decode_bin_rows({:boolean, :field_type_tiny}, packet),        do: parse_boolean_packet(packet)
   defp handle_decode_bin_rows({:decimal, :field_type_newdecimal}, packet),  do: parse_decimal_packet(packet)
+  defp handle_decode_bin_rows({:float, :field_type_float}, packet),         do: parse_float_packet(packet, 32)
   defp handle_decode_bin_rows({:float, :field_type_double}, packet),        do: parse_float_packet(packet, 64)
 
   defp parse_boolean_packet(packet) do
@@ -342,6 +343,7 @@ defmodule Mariaex.Messages do
     << value :: size(size)-float-little, rest :: binary >> = packet
     {value, rest}
   end
+
   defp parse_int_packet(packet, size) do
     << value :: size(size)-little, rest :: binary >> = packet
     {value, rest}

--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -268,8 +268,8 @@ defmodule Mariaex.Messages do
   defp decode_msg(body, :rows),                                                    do: __decode__(:row, body)
 
   defp decode_string(data),    do: data
-  defp decode_float(data),     do: Float.parse(data) |> elem(0)
-  defp decode_integer(data),   do: Integer.parse(data) |> elem(0)
+  defp decode_float(data),     do: String.to_float(data)
+  defp decode_integer(data),   do: String.to_integer(data)
   defp decode_bit(<<bit>>),    do: bit
   defp decode_null(_),         do: nil
   defp decode_boolean("1"),    do: true

--- a/lib/mariaex/messages.ex
+++ b/lib/mariaex/messages.ex
@@ -320,14 +320,23 @@ defmodule Mariaex.Messages do
   end
 
   defp handle_decode_bin_rows({:string, _mysql_type}, packet),              do: length_encoded_string(packet)
-  defp handle_decode_bin_rows({:integer, :field_type_tiny}, packet),        do: parse_packet(packet, 8)
-  defp handle_decode_bin_rows({:integer, :field_type_long}, packet),        do: parse_packet(packet, 32)
-  defp handle_decode_bin_rows({:integer, :field_type_longlong}, packet),    do: parse_packet(packet, 64)
+  defp handle_decode_bin_rows({:integer, :field_type_tiny}, packet),        do: parse_int_packet(packet, 8)
+  defp handle_decode_bin_rows({:integer, :field_type_long}, packet),        do: parse_int_packet(packet, 32)
+  defp handle_decode_bin_rows({:integer, :field_type_longlong}, packet),    do: parse_int_packet(packet, 64)
   defp handle_decode_bin_rows({:time, :field_type_time}, packet),           do: parse_time_packet(packet)
   defp handle_decode_bin_rows({:date, :field_type_date}, packet),           do: parse_date_packet(packet)
   defp handle_decode_bin_rows({:timestamp, :field_type_datetime}, packet),  do: parse_datetime_packet(packet)
+  defp handle_decode_bin_rows({:boolean, :field_type_tiny}, packet),        do: parse_boolean(packet)
 
-  defp parse_packet(packet, size) do
+  defp parse_boolean(packet) do
+    << value, rest :: binary >> = packet
+    case value do
+      1 -> {true, rest}
+      0 -> {false, rest}
+    end
+  end
+
+  defp parse_int_packet(packet, size) do
     << value :: size(size)-little, rest :: binary >> = packet
     {value, rest}
   end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -40,6 +40,9 @@ defmodule QueryTest do
 
     # Binary
     [{^binary}] = query("SELECT data from #{table} WHERE id = ?", [1])
+
+    # Decimal
+    [{^decimal}] = query("SELECT value from #{table} WHERE id = ?", [1])
   end
 
   test "support primitive data types by text protocol", context do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -10,7 +10,7 @@ defmodule QueryTest do
 
   test "support primitive data types by binary protocol", context do
     integer = 1
-    float   = 3.1415
+    double   = 3.1415
     string  = "Californication"
     text    = "Some random text"
     binary  = <<0,1>>
@@ -18,13 +18,13 @@ defmodule QueryTest do
     table   = "basic_types_binary_protocol"
 
     sql = ~s{CREATE TABLE #{table} } <>
-          ~s{(id serial, active boolean, count integer, intensity float, } <>
+          ~s{(id serial, active boolean, count integer, accuracy double, } <>
           ~s{title varchar(20), body text(20), data blob, value decimal(10,2))}
 
     :ok = query(sql, [])
-    insert = ~s{INSERT INTO #{table} (active, count, intensity, title, body, data, value) } <>
+    insert = ~s{INSERT INTO #{table} (active, count, accuracy, title, body, data, value) } <>
              ~s{VALUES (?, ?, ?, ?, ?, ?, ?)}
-    :ok = query(insert, [true, integer, float, string, text, binary, decimal])
+    :ok = query(insert, [true, integer, double, string, text, binary, decimal])
 
     # Boolean
     [{true}] = query("SELECT active from #{table} WHERE id = ?", [1])
@@ -43,6 +43,9 @@ defmodule QueryTest do
 
     # Decimal
     [{^decimal}] = query("SELECT value from #{table} WHERE id = ?", [1])
+
+    # Double
+    [{^double}] = query("SELECT accuracy from #{table} WHERE id = ?", [1])
   end
 
   test "support primitive data types by text protocol", context do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -8,7 +8,41 @@ defmodule QueryTest do
     {:ok, [pid: pid]}
   end
 
-  test "support primitive data types", context do
+  test "support primitive data types by binary protocol", context do
+    integer = 1
+    float   = 3.1415
+    string  = "Californication"
+    text    = "Some random text"
+    binary  = <<0,1>>
+    decimal = Decimal.new("16.90")
+    table   = "basic_types_binary_protocol"
+
+    sql = ~s{CREATE TABLE #{table} } <>
+          ~s{(id serial, active boolean, count integer, intensity float, } <>
+          ~s{title varchar(20), body text(20), data blob, value decimal(10,2))}
+
+    :ok = query(sql, [])
+    insert = ~s{INSERT INTO #{table} (active, count, intensity, title, body, data, value) } <>
+             ~s{VALUES (?, ?, ?, ?, ?, ?, ?)}
+    :ok = query(insert, [true, integer, float, string, text, binary, decimal])
+
+    # Boolean
+    [{true}] = query("SELECT active from #{table} WHERE id = ?", [1])
+
+    # Integer
+    [{^integer}] = query("SELECT count from #{table} WHERE id = ?", [1])
+
+    # String
+    [{^string}] = query("SELECT title from #{table} WHERE id = ?", [1])
+
+    # Text
+    [{^text}] = query("SELECT body from #{table} WHERE id = ?", [1])
+
+    # Binary
+    [{^binary}] = query("SELECT data from #{table} WHERE id = ?", [1])
+  end
+
+  test "support primitive data types by text protocol", context do
     integer          = 1
     negative_integer = -1
     float            = 3.1415
@@ -16,7 +50,7 @@ defmodule QueryTest do
     string           = "Californication"
     text             = "Some random text"
     binary           = <<0,1>>
-    table            = "basic_types"
+    table            = "basic_types_text_protocol"
 
     sql = ~s{CREATE TABLE #{table} } <>
           ~s{(id serial, active boolean, count integer, intensity float, } <>
@@ -24,7 +58,7 @@ defmodule QueryTest do
 
     :ok = query(sql, [])
 
-    # Booleans
+    # Boolean
     :ok = query("INSERT INTO #{table} (active) values (?)", [true])
     [{true}] = query("SELECT active from #{table} WHERE id = LAST_INSERT_ID()", [])
 


### PR DESCRIPTION
Today we have two protocols, text and binary.

```
query(sql, []) # Uses a text protocol at the moment. 
query(sql, params) # Uses a binary protocol
```

The text protocol has the basic support for now, so it was needed to add the following types for binaries:
  * Float
  * Double
  * Decimal
  * Boolean


Continues https://github.com/liveforeverx/mariaex/pull/26