### PR TITLE
Encode decode nulls

### DIFF
--- a/lib/mariaex/coder.ex
+++ b/lib/mariaex/coder.ex
@@ -185,7 +185,7 @@ defmodule Mariaex.Coder do
   defmodule Utils do
     def length_encoded_string(bin) do
       case bin do
-        << 251 :: 8, rest :: bits >> -> {:undefined, rest}
+        << 251 :: 8, rest :: bits >> -> {nil, rest}
         _ ->
           {length, next} = length_encoded_integer(bin)
           << string :: size(length)-binary, next :: binary >> = next

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -115,7 +115,6 @@ defmodule QueryTest do
   test "encode and decode nils", context do
     double  = 3.1415
     decimal = Decimal.new("18.93")
-    integer = 16
     table   = "encoding_and_decoding_nils"
 
     sql = ~s{CREATE TABLE #{table} } <>
@@ -130,6 +129,28 @@ defmodule QueryTest do
 
     :ok = query(insert, [nil, double, nil])
     [{nil, ^double, nil}] = query("SELECT count, accuracy, value from #{table} WHERE id = ?", [2])
+  end
+
+  test "encode and decode nils with more than 8 columns", context do
+    table = "encoding_and_decoding_multiple_columns"
+
+    sql = ~s{CREATE TABLE #{table} } <>
+          ~s{(id serial, count_1 integer, count_2 integer, count_3 integer, count_4 integer, } <>
+          ~s{count_5 integer, count_6 integer, count_7 integer, count_8 integer, } <>
+          ~s{count_9 integer, count_10 integer)}
+
+
+    :ok = query(sql, [])
+
+    insert = ~s{INSERT INTO #{table} (count_1, count_2, count_3, count_4, count_5, } <>
+             ~s{count_6, count_7, count_8, count_9, count_10) } <>
+             ~s{VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)}
+
+    values = [1, nil, 3, 4, nil, 6, nil, 8, nil, 10]
+    result = {1, 1, nil, 3, 4, nil, 6, nil, 8, nil, 10}
+
+    :ok = query(insert, values)
+    [^result] = query("SELECT * FROM #{table}", [])
   end
 
   test "encode and decode decimals", context do


### PR DESCRIPTION
This PR fixes the encoding and decoding for `NULL`'s when passed to `INSERT` and received on `SELECT`.

We had to fix the `null_map_to_mysql` because it was actually not reverting the bits. 

Documentation for the null bitmap is here -> http://dev.mysql.com/doc/internals/en/null-bitmap.html

Huge thanks to @josevalim who did most part of the job :heart: 