### PR TITLE
Return the last_insert_id on MariaexResult struct

### DIFF
--- a/lib/mariaex/protocol.ex
+++ b/lib/mariaex/protocol.ex
@@ -70,11 +70,11 @@ defmodule Mariaex.Protocol do
     end
   end
 
-  def dispatch(packet(msg: ok_resp(affected_rows: affected_rows)), state = %{statement: statement, state: s})
+  def dispatch(packet(msg: ok_resp(affected_rows: affected_rows, last_insert_id: last_insert_id)), state = %{statement: statement, state: s})
    when s in [:handshake_send, :query_send, :execute_send] do
     command = get_command(statement)
     rows = if (command in [:create, :insert, :update, :delete, :begin, :commit, :rollback]) do nil else [] end
-    result = {:ok, %Mariaex.Result{command: command, columns: [], rows: rows, num_rows: affected_rows}}
+    result = {:ok, %Mariaex.Result{command: command, columns: [], rows: rows, num_rows: affected_rows, last_insert_id: last_insert_id}}
     {_, state} = Connection.reply(result, state)
     %{ state | state: :running, substate: nil }
   end

--- a/lib/mariaex/structs.ex
+++ b/lib/mariaex/structs.ex
@@ -14,9 +14,10 @@ defmodule Mariaex.Result do
     command:  atom,
     columns:  [String.t] | nil,
     rows:     [tuple] | nil,
+    last_insert_id: integer,
     num_rows: integer}
 
-  defstruct [:command, :columns, :rows, :num_rows]
+  defstruct [:command, :columns, :rows, :last_insert_id, :num_rows]
 end
 
 defmodule Mariaex.Error do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -242,11 +242,24 @@ defmodule QueryTest do
     :ok = query("COMMIT", [])
   end
 
-  test "result struct", context do
+  test "result struct on select", context do
     {:ok, res} = Mariaex.Connection.query(context[:pid], "SELECT 1 AS first, 10 AS last", [])
-    %Mariaex.Result{} = res
+
+    assert %Mariaex.Result{} = res
     assert res.command == :select
     assert res.columns == ["first", "last"]
+    assert res.num_rows == 1
+  end
+
+  test "result struct on insert", context do
+    table = "result_on_insert"
+
+    :ok = query("CREATE TABLE #{table} (id serial, title text)", [])
+    {:ok, res} = Mariaex.Connection.query(context[:pid], "INSERT INTO #{table} (title) values ('abc')", [])
+
+    assert %Mariaex.Result{} = res
+    assert res.command == :insert
+    assert res.columns == []
     assert res.num_rows == 1
   end
 


### PR DESCRIPTION
With this change, we won't need to make another query to the database to
get the `last_insert_id`.